### PR TITLE
Print errors on nelson unit commit failures

### DIFF
--- a/src/github.com/getnelson/nelson/main.go
+++ b/src/github.com/getnelson/nelson/main.go
@@ -540,7 +540,11 @@ func main() {
 								unitWithVersion := selectedUnitPrefix + "@" + selectedVersion
 
 								if e != nil {
-									return cli.NewExitError("Unable to commit "+unitWithVersion+" to '"+selectedNamespace+"'. Response was:\n"+r, 1)
+									errors := ""
+									for _, ee := range e {
+										errors += fmt.Sprintf("%s\n", ee.Error())
+									}
+									return cli.NewExitError(fmt.Sprintf("Unable to commit %s to '%s'. Response was:\n%s\nErrors:\n%s", unitWithVersion, selectedNamespace, r, errors), 1)
 								} else {
 									fmt.Println("===>> Commited " + unitWithVersion + " to '" + selectedNamespace + "'.")
 								}


### PR DESCRIPTION
When an empty response is returned from Nelson, users are shown an error without any content:

```
Unable to commit xxxxxx@2.0.nnnn to 'prod'. Response was:

```

This prints the errors block as part of the message. Doesn't actually fix any errors, but might help to identify if it's a timeout/other transient issue.

Fixes #22 