### PR TITLE
Write errors to stderr

### DIFF
--- a/src/github.com/getnelson/nelson/util.go
+++ b/src/github.com/getnelson/nelson/util.go
@@ -122,7 +122,7 @@ func PrintTerminalErrors(errs []error) {
 	}
 
 	for _, e := range errs {
-		fmt.Println(e)
+		_, _ = fmt.Fprintln(os.Stderr, e)
 	}
 }
 


### PR DESCRIPTION
Altered the `PrintTerminalErrors` func to write to stderr rather than stdout.

Currently if you are piping the output of nelson and the command fails (say when you can't reach the server due to VPN etc), no errors are printed as they are swallowed by the pipe from stdout:

```
$ nelson --timeout 2 stacks list -n dev | grep asd
Unable to list stacks.
```

This change ensures that the errors returned are actually printed to better inform users.