### PR TITLE
Fix error printing when login command fails

### DIFF
--- a/src/github.com/getnelson/nelson/main.go
+++ b/src/github.com/getnelson/nelson/main.go
@@ -123,8 +123,13 @@ func main() {
 				// fmt.Println("token: ", userGithubToken)
 				// fmt.Println("host: ", host)
 				pi.Start()
-				Login(http, userGithubToken, host, disableTLS)
+				errs := Login(http, userGithubToken, host, disableTLS)
 				pi.Stop()
+				if len(errs) != 0 {
+					PrintTerminalErrors(errs)
+					return cli.NewExitError("Login failed.", 1)
+				}
+
 				fmt.Println("Successfully logged in to " + host)
 				return nil
 			},


### PR DESCRIPTION
Currently, when the login command fails, it looks like this -

```
> nelson login nelson.example.com
/ Post https://nelson.example.com/auth/github: dial tcp 10.10.10.10:443: connect: operation timed oSuccessfully logged in to nelson.example.com
```

This is confusing as the login actually failed yet it says "Successfully logged in", and it also truncates the error message.

This PR fixes that by ensuring all the errors are printed properly without the spinner interfering. It also returns a non-zero exit code in this scenario, honours the global timeout setting, and moves the error to the end of the return arg list as per Go convention.

There is a minor change in timeout behaviour too - previously, the login command would wait until the server times out. Now, it has a default timeout of 60 seconds, in line with all the other commands.

```
> nelson login nelson.example.com
Post https:/nelson.example.com/auth/github: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
Login failed.
```